### PR TITLE
Fix-prediction-inverse-mapping

### DIFF
--- a/dqc/crossval.py
+++ b/dqc/crossval.py
@@ -120,7 +120,7 @@ class CrossValCurate(BaseCurate):
                 else `False`
         """
         threshold = self.correctness_threshold
-        if (row["predicted_label"] == row[self.y_col_name_int]) and (
+        if (row["predicted_label_int"] == row[self.y_col_name_int]) and (
             row["label_correctness_score"] >= threshold
         ):
             return True
@@ -275,7 +275,7 @@ class CrossValCurate(BaseCurate):
             random_state=self.random_state,
         )
 
-        input_data, row_id_col, y_col_name_int = dp._preprocess(
+        input_data, row_id_col, y_col_name_int, inv_label_mapping = dp._preprocess(
             input_data, y_col_name=y_col_name
         )
 
@@ -353,7 +353,8 @@ class CrossValCurate(BaseCurate):
 
         # Add results as columns
         input_data["label_correctness_score"] = pd.Series(label_correctness_scores)
-        input_data["predicted_label"] = pd.Series(predictions)
+        input_data["predicted_label_int"] = pd.Series(predictions)
+
         input_data["prediction_probability"] = pd.Series(prediction_probabilities)
 
         logger.info("Identifying the correctly labelled samples..")
@@ -364,4 +365,5 @@ class CrossValCurate(BaseCurate):
         return dp._postprocess(
             input_data,
             display_cols=list(data_with_noisy_labels.columns) + self.result_col_list,
+            inv_label_mapping=inv_label_mapping,
         )

--- a/dqc/utils/_sanitychecks.py
+++ b/dqc/utils/_sanitychecks.py
@@ -52,6 +52,20 @@ def _check_columns(data: pd.DataFrame, X_col_name: str, y_col_name: str):
         )
 
 
+def _check_blank_values(series: pd.Series):
+    """Sanity checks to detect blank values in the input series
+
+    Args:
+        series (pd.Series): The Pandas Series object potentially containing blank values
+
+    Returns:
+        bool: `True` if `series` contains blank values else `False`
+    """
+    series_stripped = series.astype(str).str.strip()
+
+    return (series_stripped == "").any()
+
+
 def _check_null_values(data: pd.DataFrame, X_col_name: str, y_col_name: str):
     """Sanity checks to detect null values in data
 
@@ -66,6 +80,12 @@ def _check_null_values(data: pd.DataFrame, X_col_name: str, y_col_name: str):
     if any(data[col].isnull().any() for col in [X_col_name, y_col_name]):
         raise ValueError(
             "Null values found in the data. \
+                    Automatically imputing missing values is not supported yet."
+        )
+
+    if _check_blank_values(data[y_col_name]):
+        raise ValueError(
+            f"Column '{y_col_name}' contains blank values. \
                     Automatically imputing missing values is not supported yet."
         )
 


### PR DESCRIPTION
- `predicted_label` returned by `CrossValCurate.fit_transform` contains integer values irrespective of the data type in the input label column. Fix this by mapping the predictions to the corresponding value in the input label list.
- Add sanity checks to handle cases where input labels can be blank strings
- Add the corresponding tests